### PR TITLE
Don't use locale in to_string

### DIFF
--- a/lib/cpp/src/thrift/TToString.h
+++ b/lib/cpp/src/thrift/TToString.h
@@ -35,7 +35,7 @@ namespace thrift {
 template <typename T>
 std::string to_string(const T& t) {
   std::ostringstream o;
-  o.imbue(std::locale("C"));
+  o.imbue(std::locale::classic());
   o << t;
   return o.str();
 }
@@ -44,7 +44,7 @@ std::string to_string(const T& t) {
 // is enabled.
 inline std::string to_string(const float& t) {
   std::ostringstream o;
-  o.imbue(std::locale("C"));
+  o.imbue(std::locale::classic());
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<float>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();
@@ -52,7 +52,7 @@ inline std::string to_string(const float& t) {
 
 inline std::string to_string(const double& t) {
   std::ostringstream o;
-  o.imbue(std::locale("C"));
+  o.imbue(std::locale::classic());
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<double>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();
@@ -60,7 +60,7 @@ inline std::string to_string(const double& t) {
 
 inline std::string to_string(const long double& t) {
   std::ostringstream o;
-  o.imbue(std::locale("C"));
+  o.imbue(std::locale::classic());
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<long double>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();


### PR DESCRIPTION
`std::locale("C")` doesn't work in clickhouse because we disallow `localeconv` libc function (in `ClickHouse/base/harmful/harmful.c`). Thrift does `std::ostream::imbue(std::locale("C"))` when formatting thrift structs as string, presumably to make formatting of floats independent of environment. This PR just replaces `std::locale("C")` with `std::locale::classic()`, which should be equivalent according to documentation (`Returns a reference to the "C" locale`), but doesn't  call `localeconv`.